### PR TITLE
Fixes (mainly) for publishing

### DIFF
--- a/plugin/ayon_openassetio_manager/ayon_core_util.py
+++ b/plugin/ayon_openassetio_manager/ayon_core_util.py
@@ -318,6 +318,8 @@ def publish_representation(
 
     thumbnailSource = file_or_files[0] if isinstance(
         file_or_files, list) else file_or_files
+    if stagingDir := representation_data.get("stagingDir"):
+        thumbnailSource = os.path.join(stagingDir, thumbnailSource)
 
     instance = pyblish_ctx.create_instance(entity_info.product_name)
     instance.data.update(

--- a/plugin/ayon_openassetio_manager/ayon_core_util.py
+++ b/plugin/ayon_openassetio_manager/ayon_core_util.py
@@ -400,7 +400,7 @@ def publish_representation(
 
 def publish_workfile(
     entity_info: ayon.EntityInfo,
-    entity_identity: dict[str, str],
+    task_id: str,
     workfile_path: str,
     note: str = "",
 ) -> None:
@@ -410,14 +410,13 @@ def publish_workfile(
 
     Args:
         entity_info (ayon.EntityInfo): The entity information.
-        entity_identity (dict[str, str]): The entity identity containing at
-            least the folderId and taskId.
+        task_id (str): Task to associate with workfile.
         workfile_path (str): The path to the workfile to register.
         note (str): An optional note to associate with the workfile.
 
     """
     _OpenAssetIOWorkfileController(OpenAssetIOHost(entity_info)).save_workfile_info(
-        entity_identity["folderId"], entity_info.task_name, workfile_path, note
+        task_id, workfile_path, comment=note
     )
 
 

--- a/plugin/ayon_openassetio_manager/manager_core.py
+++ b/plugin/ayon_openassetio_manager/manager_core.py
@@ -411,11 +411,11 @@ class AyonOpenAssetIOManagerInterfaceCore:
                             frame_ranged_trait.setFramesPerSecond(fps)
 
                 # Colour space
-                if mc_traits.color.OCIOColorManagedTrait.kId in trait_set and (
-                colorspace := entity_version["attrib"]["colorSpace"]):
-                    ocio_trait = mc_traits.color.OCIOColorManagedTrait(
-                        traits_data)
-                    ocio_trait.setColorspace(colorspace)
+                if mc_traits.color.OCIOColorManagedTrait.kId in trait_set:
+                    if colorspace := entity_version["attrib"].get("colorSpace"):
+                        ocio_trait = mc_traits.color.OCIOColorManagedTrait(
+                            traits_data)
+                        ocio_trait.setColorspace(colorspace)
 
             if traits_data.traitSet():
                 # Add entity info to context for use in UI pre-population, etc.

--- a/plugin/ayon_openassetio_manager/manager_core.py
+++ b/plugin/ayon_openassetio_manager/manager_core.py
@@ -623,7 +623,7 @@ class AyonOpenAssetIOManagerInterfaceCore:
         )
 
         for idx, (entity_ref, entity_traits_data) in enumerate(
-            zip(target_entity_refs, entity_traits_datas)
+            zip(target_entity_refs, entity_traits_datas, strict=True)
         ):
             entity_info = ayon.parse_entity_ref(str(entity_ref))
             is_workfile = entity_info.representation_name is None
@@ -656,7 +656,7 @@ class AyonOpenAssetIOManagerInterfaceCore:
                 instance_data["colorspace"] = colorspace
 
             # Find all the files.
-            file_or_files: list[str] = []
+            multiple_files: list[str] = []
             single_file: str | None = None
             if url := mc_traits.content.LocatableContentTrait(
                     entity_traits_data).getLocation():
@@ -665,7 +665,7 @@ class AyonOpenAssetIOManagerInterfaceCore:
                     self.__fileUrlPathConverter.pathFromUrl(url)
                 )
                 if is_workfile:
-                    file_or_files = [str(path)]
+                    single_file = str(path)
                 else:
                     # AYON uses "stagingDir" to mean the parent directory that
                     # all the files were written to. This could be the staging
@@ -675,7 +675,7 @@ class AyonOpenAssetIOManagerInterfaceCore:
                     # artifacts can be found.
                     instance_data["stagingDir"] = str(path.parent)
                     if not frame_ranged_trait.isImbued():
-                        file_or_files.append(path.name)
+                        single_file = path.name
                     else:
                         # TODO(DF): We assume that the frame token is
                         #  in the file name(s), rather than in a directory
@@ -683,66 +683,68 @@ class AyonOpenAssetIOManagerInterfaceCore:
                         frame_token = self.__create_frame_token(
                             entity_info.project_name, host_session
                         )
+                        start_frame = frame_ranged_trait.getStartFrame()
+                        end_frame = frame_ranged_trait.getEndFrame()
 
                         if frame_token not in path.name:
                             # Assume a single file, i.e. not a file
                             # sequence. In particular, a video file may
                             # have a frame range, but is only a single
                             # file.
-                            file_or_files.append(path.name)
+                            single_file = path.name
 
-                        elif (
-                            frame_ranged_trait.getStartFrame() is None
-                            or frame_ranged_trait.getEndFrame() is None
-                        ):
+                        elif start_frame is None or end_frame is None:
                             # No frame range is specified, so try a glob of the
                             # file system.
                             glob_path = path.with_name(
-                                path.name.replace(frame_token, "*"))
-                            file_or_files.extend(
-                                f.name for f in glob_path.parent.glob(
-                                    glob_path.name)
+                                path.name.replace(frame_token, "*")
+                            )
+                            multiple_files.extend(
+                                f.name
+                                for f in glob_path.parent.glob(glob_path.name)
                             )
 
                         else:
                             # Frame range is specified, so we trust that it's
                             # accurate, and generate a list of files.
                             frame_padding = self.__query_frame_padding(
-                                entity_info.project_name)
-                            frame_range = range(
-                                frame_ranged_trait.getStartFrame(),
-                                frame_ranged_trait.getEndFrame() + 1,
+                                entity_info.project_name
                             )
+                            frame_range = range(start_frame, end_frame + 1)
 
-                            file_or_files.extend(
+                            multiple_files.extend(
                                 path.name.replace(
-                                    frame_token,
-                                    f"{frame:0{frame_padding}}")
+                                    frame_token, f"{frame:0{frame_padding}}"
+                                )
                                 for frame in frame_range
                             )
 
-                    if len(file_or_files) == 1:
-                        # AYON will complain if we try to pass a "sequence"
-                        # containing a single file. We flag that it's not a
-                        # sequence by passing a single string.
-                        single_file = file_or_files[0]
-
-            if not file_or_files or not single_file:
-                host_session.logger().error(
-                    f"No files found to publish for entity reference '{entity_ref}': "
-                    f"{file_or_files}")
-                error_callback(
-                    idx, BatchElementError(
-                        BatchElementError.ErrorCode.kInvalidPreflightHint,
-                        "No files found to publish."))
-                continue
+            if len(multiple_files) == 1:
+                # AYON will complain if we try to pass a "sequence" containing
+                # a single file. We flag that it's not a sequence by passing a
+                # single string.
+                single_file = multiple_files.pop()
 
             if not is_workfile:
+                if not single_file and not multiple_files:
+                    host_session.logger().error(
+                        "No files found to publish representation for entity"
+                        f" reference '{entity_ref}'"
+                    )
+                    error_callback(
+                        idx,
+                        BatchElementError(
+                            BatchElementError.ErrorCode.kInvalidPreflightHint,
+                            "No files found to publish representation.",
+                        ),
+                    )
+                    continue
+
                 # Execute the AYON Pyblish process.
                 published_ids = ayon_core_util.publish_representation(
                     entity_info,
                     instance_data,
-                    file_or_files or single_file,
+                    single_file or multiple_files,
                     host_session.logger(),
                 )
                 # Convert IDs to AYON URIs (i.e. entity references).
@@ -753,17 +755,28 @@ class AyonOpenAssetIOManagerInterfaceCore:
                 )
                 final_entity_ref_str = uri_response.data["uris"][-1]["uri"]
             else:
+                if not single_file:
+                    host_session.logger().error(
+                        "No files found to publish workfile for entity"
+                        f" reference '{entity_ref}'"
+                    )
+                    error_callback(
+                        idx,
+                        BatchElementError(
+                            BatchElementError.ErrorCode.kInvalidPreflightHint,
+                            "No files found to publish workfile.",
+                        ),
+                    )
+                    continue
+
                 # Assume a (in-progress) workfile
                 ayon_core_util.publish_workfile(
                     entity_info,
-                    entity_identities[idx]["entities"][-1],
+                    entity_identities[idx]["entities"][-1]["taskId"],
                     single_file
                 )
-                file = (
-                    file_or_files[0]
-                    if isinstance(file_or_files, list) else file_or_files
-                )
-                entity_info.workfile_name = pathlib.Path(file).name
+
+                entity_info.workfile_name = pathlib.Path(single_file).name
                 entity_info.representation_name = None
                 entity_info.product_name = None
                 entity_info.product_type = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ayon-openassetio-manager-plugin"
 version = "0.2.0"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name="AYON Team", email = "info@ynput.io" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "attrs",
     # Support caching
     "cachetools",
-    "openassetio-traitgen"
 ]
 
 [project.optional-dependencies]
@@ -36,6 +35,20 @@ ui = [
 openassetio = [
     "openassetio>=1.0.0",
     "openassetio-mediacreation>=1.0.0a12",
+]
+
+[dependency-groups]
+
+traitgen = [
+    "openassetio-traitgen",
+]
+
+dev = [
+    "openassetio>=1.0.0",
+    "openassetio-mediacreation>=1.0.0a12",
+    "pytest",
+    "pytest-print",
+    "ruff",
 ]
 
 [project.urls]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -756,6 +756,87 @@ class TestRegister:
         assert pathlib.Path(final_path.format(frame=2)).is_file()
         assert pathlib.Path(final_path.format(frame=1)) != pathlib.Path(final_path.format(frame=2))
 
+    def test_when_publishing_single_file_as_representation_then_creates_non_sequence(
+        self, project: ProjectInfo, manager: Manager
+    ) -> None:
+        # setup
+
+        context = manager.createContext()
+
+        traits_hint = mc_specs.twoDimensional.PlanarBitmapImageResourceSpecification.create().traitsData()
+        mc_traits.timeDomain.FrameRangedTrait.imbueTo(traits_hint)
+
+        working_ref = manager.preflight(
+            entityReference=manager.createEntityReference(
+                f"ayon+entity://{project.project_name}/"
+                f"{project.folder.name}?"
+                "product=plateMainSingle&"
+                "product_type=plate&"
+                "representation=blah"
+            ),
+            traitsHint=traits_hint,
+            publishAccess=access.PublishingAccess.kWrite,
+            context=context,
+        )
+
+        manager_driven_traits_data = manager.resolve(
+            entityReference=working_ref,
+            traitSet={mc_traits.content.LocatableContentTrait.kId},
+            resolveAccess=openassetio.access.ResolveAccess.kManagerDriven,
+            context=context,
+        )
+
+        manager_driven_locatable_content_trait = (
+            mc_traits.content.LocatableContentTrait(manager_driven_traits_data)
+        )
+
+        asset_template_path = FileUrlPathConverter().pathFromUrl(
+            manager_driven_locatable_content_trait.getLocation()
+        )
+
+        asset_path = asset_template_path.format(frame=1)
+        pathlib.Path(asset_path).touch()
+
+        traits_data = TraitsData(traits_hint)
+        mc_traits.content.LocatableContentTrait(traits_data).setLocation(
+            manager_driven_locatable_content_trait.getLocation()
+        )
+
+        # action
+
+        final_ref = manager.register(
+            entityReference=working_ref,
+            entityTraitsData=traits_data,
+            publishAccess=access.PublishingAccess.kWrite,
+            context=context,
+        )
+
+        #  confirm
+
+        expected_final_ref = manager.createEntityReference(
+            f"ayon+entity://{project.project_name}/"
+            f"{project.folder.name}?"
+            "product=plateMainSingle&"
+            "version=v001&"
+            "representation=blah"
+        )
+
+        assert final_ref == expected_final_ref
+
+        final_traits_data = manager.resolve(
+            expected_final_ref,
+            {mc_traits.content.LocatableContentTrait.kId},
+            access.ResolveAccess.kRead,
+            context,
+        )
+
+        final_uri = mc_traits.content.LocatableContentTrait(
+            final_traits_data
+        ).getLocation()
+
+        final_path = FileUrlPathConverter().pathFromUrl(final_uri)
+        assert pathlib.Path(final_path).is_file()
+
     def test_when_publishing_to_new_workfile_then_creates_new_workfile_entry(
         self, project: ProjectInfo, manager: Manager
     ) -> None:


### PR DESCRIPTION
## Changelog Description

Fix a couple of bugs when publishing:

* There were logic flaws when deciding between publishing single or multiple files. In particular, `["myfile.png"]` (i.e. a list of one path) took precedence over `"myfile.png"` (i.e. just path string on its own), resulting in errors like `KnownPublishError("Files of representation does not contain proper sequence files\nCollected collections: []\nCollected remainders: myfile.png")`.
* The signature `BaseWorkfileController.save_workfile_info` has changed as of ayon_core 1.5.0.
* When `stagingDir` is available, the `thumbmailSource` still needs to be the absolute path to the file, rather than just the file name.

It was observed that  the `"colorSpace"` key can be missing in the otherwise valid server response (because there legitimately isn't one), so we should tolerate that.

Also finess the pyproject.toml a little to update allowed Python version range to match OpenAssetIO, and fiddle with dependency groups.

## Additional review information

A test case was already failing before these changes (workfile publishing).  A new test case has been added to check the single vs. multiple file logic.
